### PR TITLE
Add support for kDNSServiceFlagsMoreComing

### DIFF
--- a/dnssd.go
+++ b/dnssd.go
@@ -56,7 +56,8 @@ const InterfaceIndexAny = 0
 const InterfaceIndexLocalOnly = int(^uint(0) >> 1)
 
 const (
-	_FlagsAdd             uint32 = 0x2
+	_FlagsMoreComing      uint32 = 0x1
+	_FlagsAdd                    = 0x2
 	_FlagsNoAutoRename           = 0x8
 	_FlagsShareConnection        = 0x4000
 )

--- a/dnssd_test.go
+++ b/dnssd_test.go
@@ -117,7 +117,7 @@ func TestDecodeTxtKeyValue(t *testing.T) {
 }
 
 func TestQueryStartStop(t *testing.T) {
-	f := func(op *QueryOp, err error, add bool, interfaceIndex int, fullname string, rrtype, rrclass uint16, rdata []byte, ttl uint32) {
+	f := func(op *QueryOp, err error, add, more bool, interfaceIndex int, fullname string, rrtype, rrclass uint16, rdata []byte, ttl uint32) {
 	}
 	StartStopHelper(t, NewQueryOp(0, "golang.org.", 1, 1, f))
 }

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/andrewtj/dnssd"
+	"github.com/djs55/dnssd"
 	"github.com/miekg/dns"
 )
 

--- a/example_test.go
+++ b/example_test.go
@@ -113,7 +113,7 @@ func ExampleResolveOp() {
 	op.Stop()
 }
 
-func ExampleQueryCallbackFunc(op *dnssd.QueryOp, err error, add bool, interfaceIndex int, fullname string, rrtype, rrclass uint16, rdata []byte, ttl uint32) {
+func ExampleQueryCallbackFunc(op *dnssd.QueryOp, err error, add, more bool, interfaceIndex int, fullname string, rrtype, rrclass uint16, rdata []byte, ttl uint32) {
 	if err != nil {
 		// op is now inactive
 		log.Printf("Query operation failed: %s", err)
@@ -126,7 +126,7 @@ func ExampleQueryCallbackFunc(op *dnssd.QueryOp, err error, add bool, interfaceI
 	log.Printf("Query operation %s %s/%d/%d/%v (TTL: %d) on interface %d", change, fullname, rrtype, rrclass, rdata, ttl, interfaceIndex)
 }
 
-func ExampleQueryCallbackFunc_unpackRR(op *dnssd.QueryOp, err error, add bool, interfaceIndex int, fullname string, rrtype, rrclass uint16, rdata []byte, ttl uint32) {
+func ExampleQueryCallbackFunc_unpackRR(op *dnssd.QueryOp, err error, add, more bool, interfaceIndex int, fullname string, rrtype, rrclass uint16, rdata []byte, ttl uint32) {
 	// Demonstrates constructing a resource record and unpacking it using
 	// Miek Gieben's dns package (https://github.com/miekg/dns/).
 


### PR DESCRIPTION
If we want to use this library as a regular resolver we need to know when the stream of results is "finished", so we can return the results to the application.

This patch maps [kDNSServiceFlagsMoreComing](https://developer.apple.com/documentation/dnssd/1823436-anonymous/kdnsserviceflagsmorecoming) to a new flag `more`

A resolver can wait until the `more` flag is `false` and return the results as a batch.