### PR TITLE
Support kDNSServiceFlagsReturnIntermediates

### DIFF
--- a/dnssd.go
+++ b/dnssd.go
@@ -59,6 +59,7 @@ const (
 	_FlagsMoreComing      uint32 = 0x1
 	_FlagsAdd                    = 0x2
 	_FlagsNoAutoRename           = 0x8
+	_FlagsIntermediates          = 0x1000
 	_FlagsShareConnection        = 0x4000
 )
 


### PR DESCRIPTION
By default the library will dereference `CNAMES` and not return `NXDomain` errors. This patch allows clients to request these "intermediate" records by setting the flag [kDNSServiceFlagsReturnIntermediates](https://developer.apple.com/documentation/dnssd/1823436-anonymous/kdnsserviceflagsreturnintermediates?language=objc)

Signed-off-by: David Scott <dave.scott@docker.com>