### PR TITLE
handleError: acquire mutex before accessing `o`

### DIFF
--- a/queryrecord.go
+++ b/queryrecord.go
@@ -157,6 +157,8 @@ func (o *QueryOp) Stop() {
 }
 
 func (o *QueryOp) handleError(e error) {
+	o.m.Lock()
+	defer o.m.Unlock()
 	if !o.started {
 		return
 	}


### PR DESCRIPTION
This was highlighted by the Go race detector.

Signed-off-by: David Scott <dave.scott@docker.com>